### PR TITLE
Add support for marshaling Optional fields

### DIFF
--- a/howard/__init__.py
+++ b/howard/__init__.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import Generic, TypeVar
+from typing import Generic, TypeVar, Union
 from enum import EnumMeta
 
 
@@ -35,6 +35,14 @@ def _convert_to(obj, t):
     elif hasattr(t, '__origin__'):  # i.e List from typing
         args = t.__args__
         real_type = t.__origin__
+
+        # Handle Union types by assuming Optional
+        # TODO: support real Union types
+        if real_type == Union and args[-1] == type(None):
+            if obj is None:
+                return obj
+            else:
+                return _convert_to(obj, args[0])
 
         # validate
         if not isinstance(obj, real_type):

--- a/tests/test_howard.py
+++ b/tests/test_howard.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 import dataclasses
 from enum import Enum
-from typing import List, Dict
+from typing import List, Dict, Optional
 
 import pytest
 
@@ -36,6 +36,12 @@ class Party:
 @dataclass
 class Score:
     scores: Dict[str, int] = field(default_factory=dict)
+
+
+@dataclass
+class Drink:
+    name: str
+    glass_type: Optional[str] = field(default=None)
 
 
 @dataclass
@@ -124,3 +130,20 @@ def test_dict_of_hands():
     assert 'John' in obj.players.keys()
     assert isinstance(obj.players['John'], Hand)
     assert len(obj.players['John'].cards) == 3
+
+
+def test_optional_type_not_set():
+    drink = {'name': 'tequila'}
+    obj = howard.from_dict(drink, Drink)
+    assert isinstance(obj, Drink)
+    assert obj.glass_type is None
+    # TODO: currently disabled as None is not a supported exportable type
+    # assert {'name': 'tequila', 'glass_type': None} == howard.to_dict(obj)
+
+
+def test_optional_type_set():
+    drink = {'name': 'scotch', 'glass_type': 'lowball'}
+    obj = howard.from_dict(drink, Drink)
+    assert isinstance(obj, Drink)
+    assert 'lowball' == obj.glass_type
+    assert {'name': 'scotch', 'glass_type': 'lowball'} == howard.to_dict(obj)


### PR DESCRIPTION
This adds support for marshaling Optional[...] fields in `from_dict`. 

Note that currently, marshaling `None` back to a dict is not supported, which I did not address (hence the commented out assertion in the test) - I wasn't sure what the plan is around that, and I believe it should be addressed in general, regardless of Optional[..] type support - perhaps by simply allowing it, or any other / unknown type, to be returned as-is instead of throwing in `to_dict()`. 