### PR TITLE
Custom to_dict() & from_dict()

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": ".venv/bin/python"
+}

--- a/Pipfile
+++ b/Pipfile
@@ -5,10 +5,13 @@ name = "pypi"
 
 [packages]
 dataclasses = "*"
+typing-extensions = "*"
 
 [dev-packages]
 pytest = "*"
 mypy = "*"
+black = "*"
+pylint = "*"
 
 [requires]
 python_version = "3.6"

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,14 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+dataclasses = "*"
+
+[dev-packages]
+pytest = "*"
+mypy = "*"
+
+[requires]
+python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e30452a0f1a71715ab7c1896c43fdc088eff2f307942f1c6773bb10383d9c34f"
+            "sha256": "cf6be241e13432084b02387ac9dcfdf4e8e3f41b3ec764461cca02023c1904d6"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -23,9 +23,40 @@
             ],
             "index": "pypi",
             "version": "==0.6"
+        },
+        "mypy-extensions": {
+            "hashes": [
+                "sha256:37e0e956f41369209a3d5f34580150bcacfabaa57b33a15c0b25f4b5725e0812",
+                "sha256:b16cabe759f55e3409a7d231ebd2841378fb0c27a5d1994719e340e4f429ac3e"
+            ],
+            "index": "pypi",
+            "version": "==0.4.1"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:2a6c6e78e291a4b6cbd0bbfd30edc0baaa366de962129506ec8fe06bdec66457",
+                "sha256:51e7b7f3dcabf9ad22eed61490f3b8d23d9922af400fe6656cb08e66656b701f",
+                "sha256:55401f6ed58ade5638eb566615c150ba13624e2f0c1eedd080fc3c1b6cb76f1d"
+            ],
+            "index": "pypi",
+            "version": "==3.6.6"
         }
     },
     "develop": {
+        "appdirs": {
+            "hashes": [
+                "sha256:9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92",
+                "sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e"
+            ],
+            "version": "==1.4.3"
+        },
+        "astroid": {
+            "hashes": [
+                "sha256:35b032003d6a863f5dcd7ec11abd5cd5893428beaa31ab164982403bcb311f22",
+                "sha256:6a5d668d7dc69110de01cdf7aeec69a679ef486862a0850cc0fd5571505b6b7e"
+            ],
+            "version": "==2.1.0"
+        },
         "atomicwrites": {
             "hashes": [
                 "sha256:0312ad34fcad8fac3704d441f7b317e50af620823353ec657a53e981f92920c0",
@@ -39,6 +70,70 @@
                 "sha256:ca4be454458f9dec299268d472aaa5a11f67a4ff70093396e1ceae9c76cf4bbb"
             ],
             "version": "==18.2.0"
+        },
+        "black": {
+            "hashes": [
+                "sha256:817243426042db1d36617910df579a54f1afd659adb96fc5032fcf4b36209739",
+                "sha256:e030a9a28f542debc08acceb273f228ac422798e5215ba2a791a6ddeaaca22a5"
+            ],
+            "index": "pypi",
+            "version": "==18.9b0"
+        },
+        "click": {
+            "hashes": [
+                "sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13",
+                "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
+            ],
+            "version": "==7.0"
+        },
+        "isort": {
+            "hashes": [
+                "sha256:1153601da39a25b14ddc54955dbbacbb6b2d19135386699e2ad58517953b34af",
+                "sha256:b9c40e9750f3d77e6e4d441d8b0266cf555e7cdabdcff33c4fd06366ca761ef8",
+                "sha256:ec9ef8f4a9bc6f71eec99e1806bfa2de401650d996c59330782b89a5555c1497"
+            ],
+            "version": "==4.3.4"
+        },
+        "lazy-object-proxy": {
+            "hashes": [
+                "sha256:0ce34342b419bd8f018e6666bfef729aec3edf62345a53b537a4dcc115746a33",
+                "sha256:1b668120716eb7ee21d8a38815e5eb3bb8211117d9a90b0f8e21722c0758cc39",
+                "sha256:209615b0fe4624d79e50220ce3310ca1a9445fd8e6d3572a896e7f9146bbf019",
+                "sha256:27bf62cb2b1a2068d443ff7097ee33393f8483b570b475db8ebf7e1cba64f088",
+                "sha256:27ea6fd1c02dcc78172a82fc37fcc0992a94e4cecf53cb6d73f11749825bd98b",
+                "sha256:2c1b21b44ac9beb0fc848d3993924147ba45c4ebc24be19825e57aabbe74a99e",
+                "sha256:2df72ab12046a3496a92476020a1a0abf78b2a7db9ff4dc2036b8dd980203ae6",
+                "sha256:320ffd3de9699d3892048baee45ebfbbf9388a7d65d832d7e580243ade426d2b",
+                "sha256:50e3b9a464d5d08cc5227413db0d1c4707b6172e4d4d915c1c70e4de0bbff1f5",
+                "sha256:5276db7ff62bb7b52f77f1f51ed58850e315154249aceb42e7f4c611f0f847ff",
+                "sha256:61a6cf00dcb1a7f0c773ed4acc509cb636af2d6337a08f362413c76b2b47a8dd",
+                "sha256:6ae6c4cb59f199d8827c5a07546b2ab7e85d262acaccaacd49b62f53f7c456f7",
+                "sha256:7661d401d60d8bf15bb5da39e4dd72f5d764c5aff5a86ef52a042506e3e970ff",
+                "sha256:7bd527f36a605c914efca5d3d014170b2cb184723e423d26b1fb2fd9108e264d",
+                "sha256:7cb54db3535c8686ea12e9535eb087d32421184eacc6939ef15ef50f83a5e7e2",
+                "sha256:7f3a2d740291f7f2c111d86a1c4851b70fb000a6c8883a59660d95ad57b9df35",
+                "sha256:81304b7d8e9c824d058087dcb89144842c8e0dea6d281c031f59f0acf66963d4",
+                "sha256:933947e8b4fbe617a51528b09851685138b49d511af0b6c0da2539115d6d4514",
+                "sha256:94223d7f060301b3a8c09c9b3bc3294b56b2188e7d8179c762a1cda72c979252",
+                "sha256:ab3ca49afcb47058393b0122428358d2fbe0408cf99f1b58b295cfeb4ed39109",
+                "sha256:bd6292f565ca46dee4e737ebcc20742e3b5be2b01556dafe169f6c65d088875f",
+                "sha256:cb924aa3e4a3fb644d0c463cad5bc2572649a6a3f68a7f8e4fbe44aaa6d77e4c",
+                "sha256:d0fc7a286feac9077ec52a927fc9fe8fe2fabab95426722be4c953c9a8bede92",
+                "sha256:ddc34786490a6e4ec0a855d401034cbd1242ef186c20d79d2166d6a4bd449577",
+                "sha256:e34b155e36fa9da7e1b7c738ed7767fc9491a62ec6af70fe9da4a057759edc2d",
+                "sha256:e5b9e8f6bda48460b7b143c3821b21b452cb3a835e6bbd5dd33aa0c8d3f5137d",
+                "sha256:e81ebf6c5ee9684be8f2c87563880f93eedd56dd2b6146d8a725b50b7e5adb0f",
+                "sha256:eb91be369f945f10d3a49f5f9be8b3d0b93a4c2be8f8a5b83b0571b8123e0a7a",
+                "sha256:f460d1ceb0e4a5dcb2a652db0904224f367c9b3c1470d5a7683c0480e582468b"
+            ],
+            "version": "==1.3.1"
+        },
+        "mccabe": {
+            "hashes": [
+                "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
+                "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
+            ],
+            "version": "==0.6.1"
         },
         "more-itertools": {
             "hashes": [
@@ -61,6 +156,7 @@
                 "sha256:37e0e956f41369209a3d5f34580150bcacfabaa57b33a15c0b25f4b5725e0812",
                 "sha256:b16cabe759f55e3409a7d231ebd2841378fb0c27a5d1994719e340e4f429ac3e"
             ],
+            "index": "pypi",
             "version": "==0.4.1"
         },
         "pluggy": {
@@ -77,13 +173,21 @@
             ],
             "version": "==1.7.0"
         },
-        "pytest": {
+        "pylint": {
             "hashes": [
-                "sha256:488c842647bbeb350029da10325cb40af0a9c7a2fdda45aeb1dda75b60048ffb",
-                "sha256:c055690dfefa744992f563e8c3a654089a6aa5b8092dded9b6fafbd70b2e45a7"
+                "sha256:51f5a52bd31cb2db5b83ff37e3e902460eaa5591dea2739ba5d10d13ec5c5350",
+                "sha256:fe49f9ada5c8999344ac3a37541e329eaff11d014460065c4128fc94cf5cf140"
             ],
             "index": "pypi",
-            "version": "==4.0.0"
+            "version": "==2.2.0"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:1d131cc532be0023ef8ae265e2a779938d0619bb6c2510f52987ffcba7fa1ee4",
+                "sha256:ca4761407f1acc85ffd1609f464ca20bb71a767803505bd4127d0e45c5a50e23"
+            ],
+            "index": "pypi",
+            "version": "==4.0.1"
         },
         "six": {
             "hashes": [
@@ -91,6 +195,13 @@
                 "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
             ],
             "version": "==1.11.0"
+        },
+        "toml": {
+            "hashes": [
+                "sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c",
+                "sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e"
+            ],
+            "version": "==0.10.0"
         },
         "typed-ast": {
             "hashes": [
@@ -118,7 +229,14 @@
                 "sha256:edb04bdd45bfd76c8292c4d9654568efaedf76fe78eb246dde69bdb13b2dad87",
                 "sha256:f19f2a4f547505fe9072e15f6f4ae714af51b5a681a97f187971f50c283193b6"
             ],
+            "markers": "python_version < '3.7' and implementation_name == 'cpython'",
             "version": "==1.1.0"
+        },
+        "wrapt": {
+            "hashes": [
+                "sha256:d4d560d479f2c21e1b5443bbd15fe7ec4b37fe7e53d335d3b9b0a7b1226fe3c6"
+            ],
+            "version": "==1.10.11"
         }
     }
 }

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "cf6be241e13432084b02387ac9dcfdf4e8e3f41b3ec764461cca02023c1904d6"
+            "sha256": "1654b8cbe37b24ec94540ce1e4e49ab2c891b0bfa625414cbf543c122f5ad09a"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -23,14 +23,6 @@
             ],
             "index": "pypi",
             "version": "==0.6"
-        },
-        "mypy-extensions": {
-            "hashes": [
-                "sha256:37e0e956f41369209a3d5f34580150bcacfabaa57b33a15c0b25f4b5725e0812",
-                "sha256:b16cabe759f55e3409a7d231ebd2841378fb0c27a5d1994719e340e4f429ac3e"
-            ],
-            "index": "pypi",
-            "version": "==0.4.1"
         },
         "typing-extensions": {
             "hashes": [
@@ -156,7 +148,6 @@
                 "sha256:37e0e956f41369209a3d5f34580150bcacfabaa57b33a15c0b25f4b5725e0812",
                 "sha256:b16cabe759f55e3409a7d231ebd2841378fb0c27a5d1994719e340e4f429ac3e"
             ],
-            "index": "pypi",
             "version": "==0.4.1"
         },
         "pluggy": {

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,124 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "e30452a0f1a71715ab7c1896c43fdc088eff2f307942f1c6773bb10383d9c34f"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.6"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "dataclasses": {
+            "hashes": [
+                "sha256:454a69d788c7fda44efd71e259be79577822f5e3f53f029a22d08004e951dc9f",
+                "sha256:6988bd2b895eef432d562370bb707d540f32f7360ab13da45340101bc2307d84"
+            ],
+            "index": "pypi",
+            "version": "==0.6"
+        }
+    },
+    "develop": {
+        "atomicwrites": {
+            "hashes": [
+                "sha256:0312ad34fcad8fac3704d441f7b317e50af620823353ec657a53e981f92920c0",
+                "sha256:ec9ae8adaae229e4f8446952d204a3e4b5fdd2d099f9be3aaf556120135fb3ee"
+            ],
+            "version": "==1.2.1"
+        },
+        "attrs": {
+            "hashes": [
+                "sha256:10cbf6e27dbce8c30807caf056c8eb50917e0eaafe86347671b57254006c3e69",
+                "sha256:ca4be454458f9dec299268d472aaa5a11f67a4ff70093396e1ceae9c76cf4bbb"
+            ],
+            "version": "==18.2.0"
+        },
+        "more-itertools": {
+            "hashes": [
+                "sha256:c187a73da93e7a8acc0001572aebc7e3c69daf7bf6881a2cea10650bd4420092",
+                "sha256:c476b5d3a34e12d40130bc2f935028b5f636df8f372dc2c1c01dc19681b2039e",
+                "sha256:fcbfeaea0be121980e15bc97b3817b5202ca73d0eae185b4550cbfce2a3ebb3d"
+            ],
+            "version": "==4.3.0"
+        },
+        "mypy": {
+            "hashes": [
+                "sha256:8e071ec32cc226e948a34bbb3d196eb0fd96f3ac69b6843a5aff9bd4efa14455",
+                "sha256:fb90c804b84cfd8133d3ddfbd630252694d11ccc1eb0166a1b2efb5da37ecab2"
+            ],
+            "index": "pypi",
+            "version": "==0.641"
+        },
+        "mypy-extensions": {
+            "hashes": [
+                "sha256:37e0e956f41369209a3d5f34580150bcacfabaa57b33a15c0b25f4b5725e0812",
+                "sha256:b16cabe759f55e3409a7d231ebd2841378fb0c27a5d1994719e340e4f429ac3e"
+            ],
+            "version": "==0.4.1"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:447ba94990e8014ee25ec853339faf7b0fc8050cdc3289d4d71f7f410fb90095",
+                "sha256:bde19360a8ec4dfd8a20dcb811780a30998101f078fc7ded6162f0076f50508f"
+            ],
+            "version": "==0.8.0"
+        },
+        "py": {
+            "hashes": [
+                "sha256:bf92637198836372b520efcba9e020c330123be8ce527e535d185ed4b6f45694",
+                "sha256:e76826342cefe3c3d5f7e8ee4316b80d1dd8a300781612ddbc765c17ba25a6c6"
+            ],
+            "version": "==1.7.0"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:488c842647bbeb350029da10325cb40af0a9c7a2fdda45aeb1dda75b60048ffb",
+                "sha256:c055690dfefa744992f563e8c3a654089a6aa5b8092dded9b6fafbd70b2e45a7"
+            ],
+            "index": "pypi",
+            "version": "==4.0.0"
+        },
+        "six": {
+            "hashes": [
+                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
+                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
+            ],
+            "version": "==1.11.0"
+        },
+        "typed-ast": {
+            "hashes": [
+                "sha256:0948004fa228ae071054f5208840a1e88747a357ec1101c17217bfe99b299d58",
+                "sha256:10703d3cec8dcd9eef5a630a04056bbc898abc19bac5691612acba7d1325b66d",
+                "sha256:1f6c4bd0bdc0f14246fd41262df7dfc018d65bb05f6e16390b7ea26ca454a291",
+                "sha256:25d8feefe27eb0303b73545416b13d108c6067b846b543738a25ff304824ed9a",
+                "sha256:29464a177d56e4e055b5f7b629935af7f49c196be47528cc94e0a7bf83fbc2b9",
+                "sha256:2e214b72168ea0275efd6c884b114ab42e316de3ffa125b267e732ed2abda892",
+                "sha256:3e0d5e48e3a23e9a4d1a9f698e32a542a4a288c871d33ed8df1b092a40f3a0f9",
+                "sha256:519425deca5c2b2bdac49f77b2c5625781abbaf9a809d727d3a5596b30bb4ded",
+                "sha256:57fe287f0cdd9ceaf69e7b71a2e94a24b5d268b35df251a88fef5cc241bf73aa",
+                "sha256:668d0cec391d9aed1c6a388b0d5b97cd22e6073eaa5fbaa6d2946603b4871efe",
+                "sha256:68ba70684990f59497680ff90d18e756a47bf4863c604098f10de9716b2c0bdd",
+                "sha256:6de012d2b166fe7a4cdf505eee3aaa12192f7ba365beeefaca4ec10e31241a85",
+                "sha256:79b91ebe5a28d349b6d0d323023350133e927b4de5b651a8aa2db69c761420c6",
+                "sha256:8550177fa5d4c1f09b5e5f524411c44633c80ec69b24e0e98906dd761941ca46",
+                "sha256:898f818399cafcdb93cbbe15fc83a33d05f18e29fb498ddc09b0214cdfc7cd51",
+                "sha256:94b091dc0f19291adcb279a108f5d38de2430411068b219f41b343c03b28fb1f",
+                "sha256:a26863198902cda15ab4503991e8cf1ca874219e0118cbf07c126bce7c4db129",
+                "sha256:a8034021801bc0440f2e027c354b4eafd95891b573e12ff0418dec385c76785c",
+                "sha256:bc978ac17468fe868ee589c795d06777f75496b1ed576d308002c8a5756fb9ea",
+                "sha256:c05b41bc1deade9f90ddc5d988fe506208019ebba9f2578c622516fd201f5863",
+                "sha256:c9b060bd1e5a26ab6e8267fd46fc9e02b54eb15fffb16d112d4c7b1c12987559",
+                "sha256:edb04bdd45bfd76c8292c4d9654568efaedf76fe78eb246dde69bdb13b2dad87",
+                "sha256:f19f2a4f547505fe9072e15f6f4ae714af51b5a681a97f187971f50c283193b6"
+            ],
+            "version": "==1.1.0"
+        }
+    }
+}

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(
     version='1.0.3',
     packages=['howard'],
     long_description=long_description,
+    install_requires=['typing_extensions'],
     url='https://github.com/nhumrich/howard',
     long_description_content_type='text/markdown',
     license='MIT',

--- a/tests/test_howard.py
+++ b/tests/test_howard.py
@@ -163,11 +163,36 @@ def test_dict_of_hands():
     assert len(obj.players['John'].cards) == 3
 
 
-def test_dict_of_custom_serialization_hands():
+def test_dict_of_custom_deserialization_hands():
     hand1 = {'_id': 1, 'cards': [{'rank': 10, 'suit': 'h'}, {'rank': 9, 'suit': 's'}, {'rank': 1, 'suit': 'c'}]}
     hand2 = {'_id': 2, 'cards': [{'rank': 2, 'suit': 'c'}, {'rank': 10, 'suit': 'h'}]}
     d = {'party_id': 1, 'players': {'John': hand1, 'Joe': hand2}}
 
+    obj = howard.from_dict(d, PartyWithCustomSerializationHand)
+
+    assert isinstance(obj, PartyWithCustomSerializationHand)
+    assert obj.party_id == 1
+    assert len(obj.players.items()) == 2
+    assert 'John' in obj.players.keys()
+    assert isinstance(obj.players['John'], CustomSerializationHand)
+    assert len(obj.players['John'].cards) == 3
+
+
+def test_dict_of_custom_serialization_hands():
+    obj = PartyWithCustomSerializationHand(
+        party_id=1,
+        players={ 'John': CustomSerializationHand(hand_id=1,
+                                                  cards=[Card(rank=10, suit=Suit.heart),
+                                                         Card(rank=9, suit=Suit.spade),
+                                                         Card(rank=1, suit=Suit.club)]),
+                  'Joe': CustomSerializationHand(hand_id=2,
+                                                 cards=[Card(rank=2, suit=Suit.club),
+                                                        Card(rank=10, suit=Suit.heart)])})
+    hand1 = {'_id': 1, 'cards': [{'rank': 10, 'suit': 'h'}, {'rank': 9, 'suit': 's'}, {'rank': 1, 'suit': 'c'}]}
+    hand2 = {'_id': 2, 'cards': [{'rank': 2, 'suit': 'c'}, {'rank': 10, 'suit': 'h'}]}
+    d = {'party_id': 1, 'players': {'John': hand1, 'Joe': hand2}}
+    assert howard.to_dict(obj) == d
+    
     obj = howard.from_dict(d, PartyWithCustomSerializationHand)
 
     assert isinstance(obj, PartyWithCustomSerializationHand)

--- a/tests/test_howard.py
+++ b/tests/test_howard.py
@@ -9,10 +9,10 @@ import howard
 
 
 class Suit(Enum):
-    heart = 'h'
-    spade = 's'
-    diamond = 'd'
-    club = 'c'
+    heart = "h"
+    spade = "s"
+    diamond = "d"
+    club = "c"
 
 
 @dataclass
@@ -46,18 +46,14 @@ class UnsupportedFloat:
 @dataclass
 class CustomSerializationHand(Hand):
     def to_dict(self):
-        return {
-            '_id': self.hand_id,
-            'cards': list(map(howard.to_dict, self.cards))
-        }
+        return {"_id": self.hand_id, "cards": list(map(howard.to_dict, self.cards))}
 
     @classmethod
     def from_dict(cls, _dict):
-        return cls(hand_id=_dict['_id'], cards=[
-            howard.from_dict(card_dict, Card)
-            for card_dict
-            in _dict['cards']
-        ])
+        return cls(
+            hand_id=_dict["_id"],
+            cards=[howard.from_dict(card_dict, Card) for card_dict in _dict["cards"]],
+        )
 
 
 @dataclass
@@ -66,9 +62,9 @@ class PartyWithCustomSerializationHand:
     players: Dict[str, CustomSerializationHand] = field(default_factory=dict)
 
 
-@pytest.mark.parametrize('d, t', [
-    ({'hand_id': 2, 'cards': [{'rank': 2, 'suit': 'c'}]}, Hand),
-])
+@pytest.mark.parametrize(
+    "d, t", [({"hand_id": 2, "cards": [{"rank": 2, "suit": "c"}]}, Hand)]
+)
 def test_dict_is_same_coming_back(d, t):
     obj = howard.from_dict(d, t)
     assert obj
@@ -76,7 +72,7 @@ def test_dict_is_same_coming_back(d, t):
 
 
 def test_hand_is_what_we_expect():
-    d = {'hand_id': 2, 'cards': [{'rank': 2, 'suit': 'c'}, {'rank': 10, 'suit': 'h'}]}
+    d = {"hand_id": 2, "cards": [{"rank": 2, "suit": "c"}, {"rank": 10, "suit": "h"}]}
     obj = howard.from_dict(d, Hand)
 
     assert isinstance(obj, Hand)
@@ -87,7 +83,7 @@ def test_hand_is_what_we_expect():
 
 
 def test_hand_without_card():
-    d = {'hand_id': 1}
+    d = {"hand_id": 1}
     obj = howard.from_dict(d, Hand)
 
     assert isinstance(obj, Hand)
@@ -96,108 +92,167 @@ def test_hand_without_card():
 
 @pytest.mark.skip(reason="Not implemented")
 def test_unknown_field():
-    d = {'hand_i': 2}
+    d = {"hand_i": 2}
     with pytest.raises(Exception):
         howard.from_dict(d, Hand)
 
 
 def test_unsupported_type():
     with pytest.raises(TypeError):
-        howard.from_dict({'n': 2}, UnsupportedFloat)
+        howard.from_dict({"n": 2}, UnsupportedFloat)
 
 
 def test_float_instead_of_int():
-    d = {'hand_id': 2.5}
+    d = {"hand_id": 2.5}
     with pytest.raises(TypeError):
         howard.from_dict(d, Hand)
 
 
 def test_unknown_suit():
-    d = {'rank': 2, 'suit': 'a'}
+    d = {"rank": 2, "suit": "a"}
 
     with pytest.raises(Exception):
         howard.from_dict(d, Card)
 
 
 def test_dict_instead_of_list_in_hand():
-    d = {'cards': {'1': {'rank': 2, 'suit': 'c'}}}
+    d = {"cards": {"1": {"rank": 2, "suit": "c"}}}
 
     with pytest.raises(TypeError):
         howard.from_dict(d, Hand)
 
 
 def test_normal_dict():
-    d = {'scores': {'John': 3, 'Joe': -1}}
+    d = {"scores": {"John": 3, "Joe": -1}}
     obj = howard.from_dict(d, Score)
 
     assert isinstance(obj, Score)
-    assert obj.scores['John'] == 3
+    assert obj.scores["John"] == 3
 
 
 def test_dict_of_hands():
-    hand1 = {'hand_id': 1, 'cards': [{'rank': 10, 'suit': 'h'}, {'rank': 9, 'suit': 's'}, {'rank': 1, 'suit': 'c'}]}
-    hand2 = {'hand_id': 2, 'cards': [{'rank': 2, 'suit': 'c'}, {'rank': 10, 'suit': 'h'}]}
-    d = {'party_id': 1, 'players': {'John': hand1, 'Joe': hand2}}
+    hand1 = {
+        "hand_id": 1,
+        "cards": [
+            {"rank": 10, "suit": "h"},
+            {"rank": 9, "suit": "s"},
+            {"rank": 1, "suit": "c"},
+        ],
+    }
+    hand2 = {
+        "hand_id": 2,
+        "cards": [{"rank": 2, "suit": "c"}, {"rank": 10, "suit": "h"}],
+    }
+    d = {"party_id": 1, "players": {"John": hand1, "Joe": hand2}}
 
     obj = howard.from_dict(d, Party)
 
     assert isinstance(obj, Party)
     assert obj.party_id == 1
     assert len(obj.players.items()) == 2
-    assert 'John' in obj.players.keys()
-    assert isinstance(obj.players['John'], Hand)
-    assert len(obj.players['John'].cards) == 3
+    assert "John" in obj.players.keys()
+    assert isinstance(obj.players["John"], Hand)
+    assert len(obj.players["John"].cards) == 3
+
 
 def test_dict_of_hands():
-    hand1 = {'hand_id': 1, 'cards': [{'rank': 10, 'suit': 'h'}, {'rank': 9, 'suit': 's'}, {'rank': 1, 'suit': 'c'}]}
-    hand2 = {'hand_id': 2, 'cards': [{'rank': 2, 'suit': 'c'}, {'rank': 10, 'suit': 'h'}]}
-    d = {'party_id': 1, 'players': {'John': hand1, 'Joe': hand2}}
+    hand1 = {
+        "hand_id": 1,
+        "cards": [
+            {"rank": 10, "suit": "h"},
+            {"rank": 9, "suit": "s"},
+            {"rank": 1, "suit": "c"},
+        ],
+    }
+    hand2 = {
+        "hand_id": 2,
+        "cards": [{"rank": 2, "suit": "c"}, {"rank": 10, "suit": "h"}],
+    }
+    d = {"party_id": 1, "players": {"John": hand1, "Joe": hand2}}
 
     obj = howard.from_dict(d, Party)
 
     assert isinstance(obj, Party)
     assert obj.party_id == 1
     assert len(obj.players.items()) == 2
-    assert 'John' in obj.players.keys()
-    assert isinstance(obj.players['John'], Hand)
-    assert len(obj.players['John'].cards) == 3
+    assert "John" in obj.players.keys()
+    assert isinstance(obj.players["John"], Hand)
+    assert len(obj.players["John"].cards) == 3
 
 
 def test_dict_of_custom_deserialization_hands():
-    hand1 = {'_id': 1, 'cards': [{'rank': 10, 'suit': 'h'}, {'rank': 9, 'suit': 's'}, {'rank': 1, 'suit': 'c'}]}
-    hand2 = {'_id': 2, 'cards': [{'rank': 2, 'suit': 'c'}, {'rank': 10, 'suit': 'h'}]}
-    d = {'party_id': 1, 'players': {'John': hand1, 'Joe': hand2}}
+    hand1 = {
+        "_id": 1,
+        "cards": [
+            {"rank": 10, "suit": "h"},
+            {"rank": 9, "suit": "s"},
+            {"rank": 1, "suit": "c"},
+        ],
+    }
+    hand2 = {"_id": 2, "cards": [{"rank": 2, "suit": "c"}, {"rank": 10, "suit": "h"}]}
+    d = {"party_id": 1, "players": {"John": hand1, "Joe": hand2}}
 
     obj = howard.from_dict(d, PartyWithCustomSerializationHand)
 
     assert isinstance(obj, PartyWithCustomSerializationHand)
     assert obj.party_id == 1
     assert len(obj.players.items()) == 2
-    assert 'John' in obj.players.keys()
-    assert isinstance(obj.players['John'], CustomSerializationHand)
-    assert len(obj.players['John'].cards) == 3
+    assert "John" in obj.players.keys()
+    assert isinstance(obj.players["John"], CustomSerializationHand)
+    assert len(obj.players["John"].cards) == 3
 
 
 def test_dict_of_custom_serialization_hands():
     obj = PartyWithCustomSerializationHand(
         party_id=1,
-        players={ 'John': CustomSerializationHand(hand_id=1,
-                                                  cards=[Card(rank=10, suit=Suit.heart),
-                                                         Card(rank=9, suit=Suit.spade),
-                                                         Card(rank=1, suit=Suit.club)]),
-                  'Joe': CustomSerializationHand(hand_id=2,
-                                                 cards=[Card(rank=2, suit=Suit.club),
-                                                        Card(rank=10, suit=Suit.heart)])})
-    hand1 = {'_id': 1, 'cards': [{'rank': 10, 'suit': 'h'}, {'rank': 9, 'suit': 's'}, {'rank': 1, 'suit': 'c'}]}
-    hand2 = {'_id': 2, 'cards': [{'rank': 2, 'suit': 'c'}, {'rank': 10, 'suit': 'h'}]}
-    d = {'party_id': 1, 'players': {'John': hand1, 'Joe': hand2}}
+        players={
+            "John": CustomSerializationHand(
+                hand_id=1,
+                cards=[
+                    Card(rank=10, suit=Suit.heart),
+                    Card(rank=9, suit=Suit.spade),
+                    Card(rank=1, suit=Suit.club),
+                ],
+            ),
+            "Joe": CustomSerializationHand(
+                hand_id=2,
+                cards=[Card(rank=2, suit=Suit.club), Card(rank=10, suit=Suit.heart)],
+            ),
+        },
+    )
+    hand1 = {
+        "_id": 1,
+        "cards": [
+            {"rank": 10, "suit": "h"},
+            {"rank": 9, "suit": "s"},
+            {"rank": 1, "suit": "c"},
+        ],
+    }
+    hand2 = {"_id": 2, "cards": [{"rank": 2, "suit": "c"}, {"rank": 10, "suit": "h"}]}
+    d = {"party_id": 1, "players": {"John": hand1, "Joe": hand2}}
     assert howard.to_dict(obj) == d
-    
+
     obj = howard.from_dict(d, PartyWithCustomSerializationHand)
 
     assert isinstance(obj, PartyWithCustomSerializationHand)
     assert obj.party_id == 1
     assert len(obj.players.items()) == 2
-    assert 'John' in obj.players.keys()
-    assert isinstance(obj.players['John'], CustomSerializationHand)
-    assert len(obj.players['John'].cards) == 3
+    assert "John" in obj.players.keys()
+    assert isinstance(obj.players["John"], CustomSerializationHand)
+    assert len(obj.players["John"].cards) == 3
+
+
+@dataclass
+class Person:
+    name: str
+    age: int
+
+    def to_dict(self):
+        return {"type": "Person", **howard.to_dict(self, as_type=dataclass)}
+
+
+def test_dict_of_as_type():
+    person = Person(name="Steve", age=56)
+    d = howard.to_dict(person)
+    assert d == {"type": "Person", "name": "Steve", "age": 56}
+    assert howard.from_dict(d, Person) == person


### PR DESCRIPTION
 - Allows defining custom `to_dict()` & `from_dict()` for classes
 - Fixed tests
 - Added a Pipfile for development
 - Allows providing `as_type` to tread an object as different class in `to_dict()`
 - Formatted using Black