### PR TITLE
Fix: Correct the API use in the README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ class Person:
 
 
 my_dict = {'name': 'Bob', 'age': 24}
-person = howard.fromdict(my_dict, Person)
+person = howard.from_dict(my_dict, Person)
 assert person.name == 'Bob'
 assert person.age == 24
 ```


### PR DESCRIPTION
The example in the README used `howard.fromdict`, which doesn't match the actual interface. This commit fixes that.