### PR TITLE
Catch extra fields being passed to "from_dict"

### DIFF
--- a/howard/__init__.py
+++ b/howard/__init__.py
@@ -6,13 +6,13 @@ from enum import EnumMeta
 T = TypeVar('T')
 
 
-def from_dict(d: dict, t: Generic[T]) -> T:
+def from_dict(d: dict, t: Generic[T], ignore_extras: bool=True) -> T:
     if not isinstance(d, dict):
         raise TypeError("First argument must be of type dict")
     if not dataclasses.is_dataclass(t):
         raise TypeError("Second argument must be a dataclass")
 
-    return _convert_to(d, t)
+    return _convert_to(d, t, ignore_extras)
 
 
 def to_dict(obj: T, public_only=False) -> dict:
@@ -22,17 +22,19 @@ def to_dict(obj: T, public_only=False) -> dict:
     return _convert_from(obj, public=public_only)
 
 
-def _convert_to(obj, t):
+def _convert_to(obj, t, ignore_extras=True):
     kwargs = {}
     if dataclasses.is_dataclass(t):
         for f in dataclasses.fields(t):
             if f.name in obj:
                 # get value
                 value = obj[f.name]
-                kwargs[f.name] = _convert_to(value, f.type)
-        extras = set(obj.keys()) - set(kwargs.keys())
-        if extras:
-            raise TypeError(
+                kwargs[f.name] = _convert_to(value, f.type, ignore_extras=ignore_extras)
+
+        if not ignore_extras:
+            extras = set(obj.keys()) - set(kwargs.keys())
+            if extras:
+                raise TypeError(
                     f'Found unexpected keys {extras} when converting to {t}'
                 )
         return t(**kwargs)
@@ -46,12 +48,20 @@ def _convert_to(obj, t):
             raise TypeError(f'Object "{obj}" not of expected type {real_type}')
 
         if real_type == list:
-            return [_convert_to(i, args[0]) for i in obj]
+            return [
+                _convert_to(i, args[0], ignore_extras=ignore_extras)
+                for i in obj
+            ]
         elif real_type == dict:
-            return {_convert_to(k, args[0]): _convert_to(v, args[1]) for k, v in obj.items()}
+            return {
+                _convert_to(k, args[0], ignore_extras=ignore_extras): _convert_to(v, args[1], ignore_extras=ignore_extras)
+                for k, v in obj.items()
+            }
         else:
-            raise TypeError('Type {real_type} currently not supported by howard. '
-                            'Consider making a PR.')
+            raise TypeError(
+                'Type {real_type} currently not supported by howard. '
+                'Consider making a PR.'
+            )
     elif isinstance(t, EnumMeta):
         return t(obj)
 

--- a/howard/__init__.py
+++ b/howard/__init__.py
@@ -30,6 +30,11 @@ def _convert_to(obj, t):
                 # get value
                 value = obj[f.name]
                 kwargs[f.name] = _convert_to(value, f.type)
+        extras = set(obj.keys()) - set(kwargs.keys())
+        if extras:
+            raise TypeError(
+                    f'Found unexpected keys {extras} when converting to {t}'
+                )
         return t(**kwargs)
 
     elif hasattr(t, '__origin__'):  # i.e List from typing

--- a/howard/__init__.py
+++ b/howard/__init__.py
@@ -7,6 +7,20 @@ T = TypeVar('T')
 
 
 def from_dict(d: dict, t: Generic[T], ignore_extras: bool=True) -> T:
+    """
+    Initialise an instance of the dataclass t using the values in the dict d
+
+    Example:
+
+    >>> @dataclasses.dataclass
+    ... class Person:
+    ...     name: str
+    ...     age: int
+    ...
+    >>> data = {'name': 'Howard', 'age': 24}
+    >>> from_dict(data, Person)
+    Person(name='Howard', age=24)
+    """
     if not isinstance(d, dict):
         raise TypeError("First argument must be of type dict")
     if not dataclasses.is_dataclass(t):
@@ -16,6 +30,20 @@ def from_dict(d: dict, t: Generic[T], ignore_extras: bool=True) -> T:
 
 
 def to_dict(obj: T, public_only=False) -> dict:
+    """
+    Marshall a dataclass instance into a dict
+
+    Example:
+
+    >>> @dataclasses.dataclass
+    ... class Person:
+    ...     name: str
+    ...     age: int
+    ...
+    >>> instance = Person(name='Howard', age=24)
+    >>> to_dict(instance)
+    {'name': 'Howard', 'age': 24}
+    """
     if not dataclasses.is_dataclass(obj):
         raise TypeError('Argument must be a dataclass')
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --doctest-modules

--- a/tests/test_howard.py
+++ b/tests/test_howard.py
@@ -71,6 +71,23 @@ def test_hand_without_card():
     assert len(obj.cards) == 0
 
 
+def test_extra_fields_raise_error():
+    d = {'rank': 2, 'suit': 'h', 'exta': 'foo'}
+    with pytest.raises(TypeError):
+        howard.from_dict(d, Card)
+
+
+def test_extra_fields_raise_error_when_nested():
+    d = {
+            'hand_id': 2, 'cards': [
+                {'rank': 2, 'suit': 'c'},
+                {'rank': 10, 'suit': 'h', 'extra': 'foo'}
+            ]
+        }
+    with pytest.raises(TypeError):
+        howard.from_dict(d, Hand)
+
+
 def test_unsupported_type():
     with pytest.raises(TypeError):
         howard.from_dict({'n': 2}, UnsupportedFloat)


### PR DESCRIPTION
This means that additional keys in dicts passed to `from_dict` raise errors. In the future there could be an arg that allows extra keys to be silently passed through.

Solves nhumrich/howard#3