### PR TITLE
Feat: Add basic custom encoding/decoding

### DIFF
--- a/howard/__init__.py
+++ b/howard/__init__.py
@@ -6,7 +6,7 @@ from enum import EnumMeta
 T = TypeVar('T')
 
 
-def from_dict(d: dict, t: Generic[T]) -> T:
+def from_dict(d: dict, t: Generic[T], decoders=None) -> T:
     """
     Initialise an instance of the dataclass t using the values in the dict d
 
@@ -26,10 +26,10 @@ def from_dict(d: dict, t: Generic[T]) -> T:
     if not dataclasses.is_dataclass(t):
         raise TypeError("Second argument must be a dataclass")
 
-    return _convert_to(d, t)
+    return _convert_to(d, t, decoders if decoders else {})
 
 
-def to_dict(obj: T, public_only=False) -> dict:
+def to_dict(obj: T, public_only=False, encoders=None) -> dict:
     """
     Marshall a dataclass instance into a dict
 
@@ -47,17 +47,17 @@ def to_dict(obj: T, public_only=False) -> dict:
     if not dataclasses.is_dataclass(obj):
         raise TypeError('Argument must be a dataclass')
 
-    return _convert_from(obj, public=public_only)
+    return _convert_from(obj, public=public_only, encoders=encoders if encoders else {})
 
 
-def _convert_to(obj, t):
+def _convert_to(obj, t, decoders):
     kwargs = {}
     if dataclasses.is_dataclass(t):
         for f in dataclasses.fields(t):
             if f.name in obj:
                 # get value
                 value = obj[f.name]
-                kwargs[f.name] = _convert_to(value, f.type)
+                kwargs[f.name] = _convert_to(value, f.type, decoders)
         return t(**kwargs)
 
     elif hasattr(t, '__origin__'):  # i.e List from typing
@@ -69,14 +69,17 @@ def _convert_to(obj, t):
             raise TypeError(f'Object "{obj}" not of expected type {real_type}')
 
         if real_type == list:
-            return [_convert_to(i, args[0]) for i in obj]
+            return [_convert_to(i, args[0], decoders) for i in obj]
         elif real_type == dict:
-            return {_convert_to(k, args[0]): _convert_to(v, args[1]) for k, v in obj.items()}
+            return {_convert_to(k, args[0], decoders): _convert_to(v, args[1], decoders) for k, v in obj.items()}
         else:
             raise TypeError('Type {real_type} currently not supported by howard. '
                             'Consider making a PR.')
     elif isinstance(t, EnumMeta):
         return t(obj)
+
+    elif t in decoders:
+        return decoders[t](obj)
 
     elif t in (int, str, bool):
         if not isinstance(obj, t):
@@ -86,7 +89,8 @@ def _convert_to(obj, t):
         raise TypeError(f'Unsupported type {t}')
 
 
-def _convert_from(obj, public=False):
+def _convert_from(obj, public=False, encoders=None):
+    encoders = encoders if encoders else {}
     if dataclasses.is_dataclass(obj):
         d = {}
         for f in dataclasses.fields(obj):
@@ -94,14 +98,16 @@ def _convert_from(obj, public=False):
                 continue  # these attributes dont make it into the dict
             if f.metadata.get('internal', False):
                 continue  # these attributes are marked as internal
-            d[f.name] = _convert_from(getattr(obj, f.name), public=public)
+            d[f.name] = _convert_from(getattr(obj, f.name), public=public, encoders=encoders)
         return d
     elif isinstance(obj, list):
-        return [_convert_from(i, public=public) for i in obj]
+        return [_convert_from(i, public=public, encoders=encoders) for i in obj]
     elif isinstance(obj, dict):
-        return {k: _convert_from(v, public=public) for k, v in obj.items()}
+        return {k: _convert_from(v, public=public, encoders=encoders) for k, v in obj.items()}
     elif isinstance(obj.__class__, EnumMeta):
-        return _convert_from(obj.value, public=public)
+        return _convert_from(obj.value, public=public, encoders=encoders)
+    elif type(obj) in encoders:
+        return encoders[type(obj)](obj)
     elif type(obj) in (int, str, bool):
         return obj
     else:

--- a/tests/test_howard.py
+++ b/tests/test_howard.py
@@ -49,6 +49,10 @@ class CustomDateEncoding:
     start_time: datetime
     duration: timedelta
 
+    @property
+    def end_time(self):
+        return self.start_time + self.duration
+
 
 def test_customer_encoding_rountrip():
     d = {'start_time': '2020-02-20 20:20', 'duration': (5, 0, 0)}
@@ -62,6 +66,9 @@ def test_customer_encoding_rountrip():
     }
     obj = howard.from_dict(d, CustomDateEncoding, decoders=decoders)
     d_new = howard.to_dict(obj, encoders=encoders)
+    assert isinstance(obj.start_time, datetime)
+    assert isinstance(obj.duration, timedelta)
+    assert obj.end_time == datetime(2020, 2, 25, 20, 20)
     assert d == d_new
 
 

--- a/tests/test_howard.py
+++ b/tests/test_howard.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, field
 import dataclasses
+from datetime import datetime, timedelta
 from enum import Enum
 from typing import List, Dict
 
@@ -41,6 +42,37 @@ class Score:
 @dataclass
 class UnsupportedFloat:
     n: float
+
+
+@dataclass
+class CustomDateEncoding:
+    start_time: datetime
+    duration: timedelta
+
+
+def test_customer_encoding_rountrip():
+    d = {'start_time': '2020-02-20 20:20', 'duration': (5, 0, 0)}
+    decoders = {
+        datetime: lambda s: datetime.strptime(s, '%Y-%m-%d %H:%M'),
+        timedelta: lambda values: timedelta(*values)
+    }
+    encoders = {
+        datetime: lambda ts: ts.strftime('%Y-%m-%d %H:%M'),
+        timedelta: lambda td: (td.days, td.seconds, td.microseconds)
+    }
+    obj = howard.from_dict(d, CustomDateEncoding, decoders=decoders)
+    d_new = howard.to_dict(obj, encoders=encoders)
+    assert d == d_new
+
+
+def test_custom_float_roundtrip():
+    d = {'n': 5.0}
+    decoders = {float: lambda x: x}
+    encoders = {float: lambda x: x}
+    obj = howard.from_dict(d, UnsupportedFloat, decoders=decoders)
+    d_new = howard.to_dict(obj, encoders=encoders)
+    assert obj.n == 5.0
+    assert d_new == d
 
 
 @pytest.mark.parametrize('d, t', [


### PR DESCRIPTION
I want to be able to load and dump numerous unsupported types using
Howard. This functionality allows loading/dumping functions to be
specified at conversion time, on a per class basis. In the future I can
imagine a howard class to which you can pass your custom encoders and
other arguments (such as `public`/`strict`) so that the same arguments don't
need to be passed at each call of `from_dict`/`to_dict`. This could also tie
into nhumrich/howard#1 - either as a decorator or mixin.