### PR TITLE
Data class encoders

### DIFF
--- a/howard/__init__.py
+++ b/howard/__init__.py
@@ -57,7 +57,11 @@ def _convert_to(obj, t, ignore_extras=True):
             if f.name in obj:
                 # get value
                 value = obj[f.name]
-                kwargs[f.name] = _convert_to(value, f.type, ignore_extras=ignore_extras)
+                decoder = f.metadata.get('howard', {}).get('decoder')
+                if decoder:
+                    kwargs[f.name] = decoder(value)
+                else:
+                    kwargs[f.name] = _convert_to(value, f.type, ignore_extras=ignore_extras)
 
         if not ignore_extras:
             extras = set(obj.keys()) - set(kwargs.keys())
@@ -117,7 +121,11 @@ def _convert_from(obj, public=False):
                 continue  # these attributes dont make it into the dict
             if f.metadata.get('internal', False):
                 continue  # these attributes are marked as internal
-            d[f.name] = _convert_from(getattr(obj, f.name), public=public)
+            encoder = f.metadata.get('howard', {}).get('encoder')
+            if encoder:
+                d[f.name] = encoder(getattr(obj, f.name))
+            else:
+                d[f.name] = _convert_from(getattr(obj, f.name), public=public)
         return d
     elif isinstance(obj, list):
         return [_convert_from(i, public=public) for i in obj]

--- a/tests/test_howard.py
+++ b/tests/test_howard.py
@@ -19,7 +19,7 @@ class Suit(Enum):
 @dataclass
 class Card:
     rank: int
-    suit: SuitMerge pull request #7 from shevron/optional-type-support
+    suit: Suit
 
 
 @dataclass


### PR DESCRIPTION
This is a first pass at allowing users to supply custom conversion routines as part of the dataclass definition.

I like this approach: It uses the metadata property on a field as intended (an extension mechanism) to allow the logic for creating the dataclass to be embedded in the dataclass itself. The result is very flexible - just as you suggested, it can be used for validation as part of the encoding/decoding procedure, or to fetch fields from an external source, such as an API or DB. And it was also easy to implement.

If you're happy with this, I can also add some documentation to the README as part of this PR.

I like using the top level key in the metadata of `howard` to effectively "namespace" this extension, but I'm also completely open on naming conventions. Happy to rename to `howard_load` or `dump` etc.