### PR TITLE
Default value of none bug

### DIFF
--- a/howard/__init__.py
+++ b/howard/__init__.py
@@ -125,7 +125,10 @@ def _convert_from(obj, public=False):
             if encoder:
                 d[f.name] = encoder(getattr(obj, f.name))
             else:
-                d[f.name] = _convert_from(getattr(obj, f.name), public=public)
+                if getattr(obj, f.name) is None:
+                    d[f.name] = None
+                else:
+                    d[f.name] = _convert_from(getattr(obj, f.name), public=public)
         return d
     elif isinstance(obj, list):
         return [_convert_from(i, public=public) for i in obj]

--- a/howard/__init__.py
+++ b/howard/__init__.py
@@ -125,10 +125,7 @@ def _convert_from(obj, public=False):
             if encoder:
                 d[f.name] = encoder(getattr(obj, f.name))
             else:
-                if getattr(obj, f.name) is None:
-                    d[f.name] = None
-                else:
-                    d[f.name] = _convert_from(getattr(obj, f.name), public=public)
+                d[f.name] = _convert_from(getattr(obj, f.name), public=public)
         return d
     elif isinstance(obj, list):
         return [_convert_from(i, public=public) for i in obj]
@@ -137,6 +134,8 @@ def _convert_from(obj, public=False):
     elif isinstance(obj.__class__, EnumMeta):
         return _convert_from(obj.value, public=public)
     elif type(obj) in (int, str, bool, float):
+        return obj
+    elif obj is None:
         return obj
     else:
         raise TypeError(f'Unsupported type {type(obj)}')

--- a/tests/test_howard.py
+++ b/tests/test_howard.py
@@ -3,7 +3,7 @@ import dataclasses
 from datetime import date
 from enum import Enum
 
-from typing import List, Dict, Tuple, Optional, Sequence
+from typing import List, Dict, Tuple, Optional, Sequence, Union
 
 import pytest
 
@@ -240,7 +240,7 @@ def test_optional_type_set():
     assert 'lowball' == obj.glass_type
     assert {'name': 'scotch', 'glass_type': 'lowball'} == howard.to_dict(obj)
 
-    
+
 def test_strip_out_public():
     @dataclass
     class Test2:
@@ -328,3 +328,17 @@ def test_multipart_field_encoding_decoding():
     assert alice.dob == expected_dob
     # Test roundtrip:
     assert howard.to_dict(alice) == data
+
+
+def test_none_with_none_as_default():
+
+    @dataclass
+    class ProcMan:
+        schedule: Union[str, None] = field(default=None)
+        children_ids: List[str] = field(default_factory=list)
+        node_context: dict = field(default_factory=dict)
+    config = {'children_ids': []}
+    process_config = howard.from_dict(config, ProcMan)
+
+    # This would cause an error if a default value is actually "none
+    howard.to_dict(process_config)


### PR DESCRIPTION
If you default a value to `None` and you try to marshal back to a dictionary, you get the error `TypeError: Unsupported type <class 'NoneType'>`. 

This is a fix for that and a test for regression purposes. 