### PR TITLE
Add datetime marshalling.

### DIFF
--- a/howard/__init__.py
+++ b/howard/__init__.py
@@ -1,4 +1,6 @@
 import dataclasses
+from datetime import datetime
+import dateutil.parser
 from typing import Generic, TypeVar, Union
 from enum import EnumMeta
 
@@ -109,6 +111,8 @@ def _convert_to(obj, t, ignore_extras=True):
         if not isinstance(obj, t):
             raise TypeError(f'Object "{obj}" not of expected type {t}')
         return obj
+    elif t is datetime:
+        return dateutil.parser.parse(obj)
     else:
         raise TypeError(f'Unsupported type {t}')
 
@@ -137,5 +141,7 @@ def _convert_from(obj, public=False):
         return obj
     elif obj is None:
         return obj
+    elif type(obj) is datetime:
+        return obj.isoformat()
     else:
         raise TypeError(f'Unsupported type {type(obj)}')

--- a/tests/test_howard.py
+++ b/tests/test_howard.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass, field
-import dataclasses
-from datetime import date
+from datetime import date, datetime
 from enum import Enum
 
 from typing import List, Dict, Tuple, Optional, Sequence, Union
@@ -342,3 +341,21 @@ def test_none_with_none_as_default():
 
     # This would cause an error if a default value is actually "none
     howard.to_dict(process_config)
+
+
+def test_datetime_to_from_dict():
+
+    @dataclass
+    class DateTimeTest:
+        my_date: datetime
+
+    data = {'my_date': '1994-11-05T13:15:30Z'}
+    # marshal into DateTimeTest object
+    test_datetime = howard.from_dict(data, DateTimeTest)
+    # make sure it is a datetime and the right year (should be right beyond that)
+    assert type(test_datetime.my_date) is datetime
+    assert test_datetime.my_date.year == 1994
+
+    # Then go back to a dict and make sure we didn't lose any data for the datetime.
+    new_dict = howard.to_dict(test_datetime)
+    assert '1994-11-05T13:15:30' in new_dict.get('my_date')


### PR DESCRIPTION
If type is `datetime` then attempt to marshal iso compatible string into datetime object.

If type of dataclass field is a datetime object, then marshal back to an iso string.