### PR TITLE
Add tuple support

### DIFF
--- a/howard/__init__.py
+++ b/howard/__init__.py
@@ -101,7 +101,7 @@ def _convert_to(obj, t, ignore_extras=True):
             }
         else:
             raise TypeError(
-                'Type {real_type} currently not supported by howard. '
+                f'Type {real_type} currently not supported by howard. '
                 'Consider making a PR.'
             )
     elif isinstance(t, EnumMeta):

--- a/howard/__init__.py
+++ b/howard/__init__.py
@@ -94,6 +94,11 @@ def _convert_to(obj, t, ignore_extras=True):
                 _convert_to(i, args[0], ignore_extras=ignore_extras)
                 for i in obj
             ]
+        elif real_type == tuple:
+            return tuple(
+                _convert_to(i, args[0], ignore_extras=ignore_extras)
+                for i in obj
+            )
         elif real_type == dict:
             return {
                 _convert_to(k, args[0], ignore_extras=ignore_extras): _convert_to(v, args[1], ignore_extras=ignore_extras)
@@ -133,6 +138,8 @@ def _convert_from(obj, public=False):
         return d
     elif isinstance(obj, list):
         return [_convert_from(i, public=public) for i in obj]
+    elif isinstance(obj, tuple):
+        return tuple(_convert_from(i, public=public) for i in obj)
     elif isinstance(obj, dict):
         return {k: _convert_from(v, public=public) for k, v in obj.items()}
     elif isinstance(obj.__class__, EnumMeta):

--- a/tests/test_howard.py
+++ b/tests/test_howard.py
@@ -53,8 +53,9 @@ class Measurement:
 
 
 @dataclass
-class UnsupportedTuple:
-    t: Tuple
+class UnsupportedType:
+    var: complex
+
 
 @dataclass
 class Drink:
@@ -75,6 +76,12 @@ class Inner:
 @dataclass
 class Outer:
     inner: Inner
+
+
+@dataclass
+class Poem:
+    author: str
+    lines: Tuple[str]
 
 
 @pytest.mark.parametrize('d, t', [
@@ -104,6 +111,34 @@ def test_hand_without_card():
 
     assert isinstance(obj, Hand)
     assert len(obj.cards) == 0
+
+
+def test_tuple():
+    d = {
+        'author': 'Yosa Buson',
+        'lines': (
+            'Blowing from the west',
+            'Fallen leaves gather,',
+            'In the east.',
+        )
+    }
+    obj = howard.from_dict(d, Poem)
+    assert isinstance(obj.lines, tuple)
+    # roundtrip:
+    assert howard.to_dict(obj) == d
+
+
+def test_tuple_with_list():
+    d = {
+        'author': 'Yosa Buson',
+        'lines': [
+            'Blowing from the west',
+            'Fallen leaves gather,',
+            'In the east.',
+        ]
+    }
+    with pytest.raises(TypeError):
+        howard.from_dict(d, Poem)
 
 
 def test_extra_fields_are_ignored():
@@ -175,9 +210,16 @@ def test_extra_dict_value_fields_raise():
         howard.from_dict(d, Party, ignore_extras=False)
 
 
-def test_unsupported_type():
+def test_unsupported_type_from_dict():
+    d = {'var': (0, 0)}
     with pytest.raises(TypeError):
-        howard.from_dict({'t': (1, 2, 3)}, UnsupportedTuple)
+        howard.from_dict(d, UnsupportedType)
+
+
+def test_unsupported_type_to_dict():
+    obj = UnsupportedType(var=complex(0, 0))
+    with pytest.raises(TypeError):
+        howard.to_dict(obj)
 
 
 def test_float_instead_of_int():


### PR DESCRIPTION
Added tuple support as it's a relatively common type (and you can't create a frozen dataclass with a list field, but you can with a tuple field).

I'm unsure about how to handle casting between lists and tuples, however. On the face of it, the current behaviour is logical: if you pass a list as a tuple field, it'll fail as they're strictly different types. However, when unmarshalling from json, http responses etc, you'll only be receiving lists, not tuples, and it might be quite nice to handle that case natively. ie. if you pass a list as a tuple field, it won't fail and will create the dataclass.

Let me know what you think.