### PR TITLE
Fix: Correct type signature for from_dict

### DIFF
--- a/howard/__init__.py
+++ b/howard/__init__.py
@@ -1,14 +1,14 @@
 import dataclasses
 from datetime import datetime
 import dateutil.parser
-from typing import Generic, TypeVar, Union
+from typing import Type, TypeVar, Union
 from enum import EnumMeta
 
 
 T = TypeVar('T')
 
 
-def from_dict(d: dict, t: Generic[T], ignore_extras: bool=True) -> T:
+def from_dict(d: dict, t: Type[T], ignore_extras: bool = True) -> T:
     """
     Initialise an instance of the dataclass t using the values in the dict d
 


### PR DESCRIPTION
I realised that with `python=3.7.3` and `mypy=0.770`, checking the type hints for howard got me the following error:

```
howard/__init__.py:11: error: Variable "typing.Generic" is not valid as a type
howard/__init__.py:11: note: See https://mypy.readthedocs.io/en/latest/common_issues.html#variables-vs-type-aliases
Found 1 error in 1 file (checked 1 source file)
```

I think this is the signature that we want: Argument type _is_ a type, return type is an instance of that same type.